### PR TITLE
Fixed centre alignment of pictures on main page

### DIFF
--- a/files/smash.css
+++ b/files/smash.css
@@ -43,7 +43,8 @@ body{
 	transition: color .45s ease;
 }
 .allPictures{
- margin-left: 130px;
+ margin: 0 auto;
+ text-align: center;
  width: 90%;
 }
 .middle-wrapper{


### PR DESCRIPTION
Replaced the explicit pixel margin with an automatic margin and used text-align: center to put the inline level elements within to the center.
